### PR TITLE
Change lint warnings to error and fix issues.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,14 +12,14 @@ parserOptions:
   sourceType: module
 plugins:
 rules:
+  no-console:
+    - off
   linebreak-style:
-    - warn
+    - error
     - unix
   quotes:
-    - warn
+    - error
     - single
   semi:
-    - warn
+    - error
     - always
-  no-console:
-    - warn

--- a/lib/watson-conversation-setup.js
+++ b/lib/watson-conversation-setup.js
@@ -73,7 +73,7 @@ WatsonConversationSetup.prototype.setupConversationWorkspace = function(params, 
           }
         }
         if (!found) {
-          callback(new Error("Configured WORKSPACE_ID '" + validateID + "' not found!"));
+          callback(new Error('Configured WORKSPACE_ID ' + validateID + ' not found!'));
         } else {
           callback(null, workspaceID);
         }


### PR DESCRIPTION
Add checks for single quotes, unix line breaks, and semi-colons.
Turn off check for no-console, as we have multiple console
logging instances for debug.