### PR TITLE
Use correct config map name to get WORKSPACE_ID in k8s.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node
 EXPOSE 3000
 
 RUN mkdir -p /usr/src/app

--- a/watson-pizzeria-pod.yml
+++ b/watson-pizzeria-pod.yml
@@ -39,7 +39,7 @@ spec:
           - name: WORKSPACE_ID
             valueFrom:
               configMapKeyRef:
-                name: watson-pizzeria
+                name: watson-pizzeria-config
                 key: workspace_id
           - name: CONVERSATION_SERVICE_WATSON_PIZZERIA
             valueFrom:


### PR DESCRIPTION
The k8s deployment uses watson-pizzeria-pod.yml to get the
WORKSPACE_ID from the config map, but incorrectly names the config
map using watson-pizzeria. The correct name should be
watson-pizzeria-config.
Also, revert to standard Node image for Dockerfile. The Alpine version
has CR/LF issues that break the deployment.

Closes: #39