### PR TITLE
Correct link to conversation intent/entity JSON

### DIFF
--- a/doc/source/Container.md
+++ b/doc/source/Container.md
@@ -70,7 +70,7 @@ $ bx cs cluster-service-bind <cluster-ID> default $CONVERSATION_SERVICE
   <img width="50%" height="50%" src="images/import_conversation_workspace.png">
 </p>
 
-* Find the local version of [`data/pizza-advanced.json`](data/pizza-advanced.json) and select
+* Find the local version of [`data/watson-pizzeria.json`](data/watson-pizzeria.json) and select
 **Import**. Find the **Workspace ID** by clicking on the context menu of the new
 workspace and select **View details**:
 


### PR DESCRIPTION
This commit did something similar, but missed this mention:

    https://github.com/IBM/watson-conversation-slots-intro/commit/250382d8b41b4f1f905a50f781c641f2c792f630