### PR TITLE
Ensure run-server.sh is executable in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 3000
 WORKDIR /app
 
 ADD . /app
+RUN chmod +x /app/run-server.sh
 
 RUN npm install
 


### PR DESCRIPTION
Executable permissions are being lost when deployed as a starter kit to Kube, because the entire repo gets zipped up without preserving executable bits. So, by the time the `Dockerfile` is built for the starter kit, `run-server.sh` won't be executable anymore.

> make sure to `chmod +x` the file in your docker file before executing