### PR TITLE
Use same env var name as starter kits

### DIFF
--- a/doc/source/Container.md
+++ b/doc/source/Container.md
@@ -9,7 +9,7 @@ $ export CONVERSATION_SERVICE=conversation-service-watson-pizzeria
 $ export CONFIG_MAP=watson-pizzeria-config
 $ export POD_NAME=watson-pizzeria-pod.yml
 $ export KUBE_SERVICE=pizza-bot
-$ export CONTAINER_ENV_VARIABLE=CONVERSATION_SERVICE_WATSON_PIZZERIA
+$ export CONTAINER_ENV_VARIABLE=service_watson_conversation
 ```
 
 # Steps

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -x
-export CONVERSATION_PASSWORD=$(echo "$CONVERSATION_SERVICE_WATSON_PIZZERIA" | jq -r '.password')
-export CONVERSATION_USERNAME=$(echo "$CONVERSATION_SERVICE_WATSON_PIZZERIA" | jq -r '.username')
+export CONVERSATION_USERNAME=$(echo "$service_watson_conversation" | jq -r '.username')
+export CONVERSATION_PASSWORD=$(echo "$service_watson_conversation" | jq -r '.password')
 npm start

--- a/watson-pizzeria-pod.yml
+++ b/watson-pizzeria-pod.yml
@@ -41,7 +41,7 @@ spec:
               configMapKeyRef:
                 name: watson-pizzeria-config
                 key: workspace_id
-          - name: CONVERSATION_SERVICE_WATSON_PIZZERIA
+          - name: service_watson_conversation
             valueFrom:
               secretKeyRef:
                 name: binding-conversation-service-watson-pizzeria


### PR DESCRIPTION
This should be an inconsequential change for non-starter kit deployments
to kube, but starter kits devops has a pre-defined variable naming
scheme for service credentials of the form:

    service_${service_type}

(where `${service_type}` is `watson_conversation` in this case)

The value is what was already expected by the app (a JSON object
containing a URL, username, and password).