### PR TITLE
Remove starter kit CLI support

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -41,8 +41,7 @@
     "conversation": "free"
   },
   "tags": [
-    "devex",
-    "cli"
+    "devex"
   ],
   "thumbnailURL": "blueprint/thumbnail.svg",
   "type": "WEB"


### PR DESCRIPTION
The `bx dev deploy` command does not properly support all starter kits,
and so we shouldn't advertise all starter kits via the CLI.