### PR TITLE
Promote starter kit to production

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -41,7 +41,7 @@
     "conversation": "free"
   },
   "tags": [
-    "devex"
+    "watson"
   ],
   "thumbnailURL": "blueprint/thumbnail.svg",
   "type": "WEB"


### PR DESCRIPTION
By merging this patch, this starter kit will be promoted to the production IBM Cloud, and become available for customers to use.

I manually tested this starter kit via both Cloud Foundry pipeline and Kubernetes. It also happens to work via `bx dev deploy`, but support for that has been removed to make the CLI team happy.