### PR TITLE
Remove generator artifact for Cloud Foundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,4 +1,0 @@
-.git/
-node_modules/
-test/
-vcap-local.js


### PR DESCRIPTION
This is produced at build time and no longer needs to be version controlled.