### PR TITLE
add .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Add a `.cfignore` file that prevents uploading `node_modules` when deploying the app.

fixes #87