### PR TITLE
Remove deprecated .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-# Environment variables
-WORKSPACE_ID=<put Watson Conversation Worksace ID here>
-CONVERSATION_USERNAME=<put Watson Conversation User Name here>
-CONVERSATION_PASSWORD=<put Watson Conversation Password here>


### PR DESCRIPTION
We now use env.example.