### PR TITLE
Fix handling "No" to extra toppings.

### DIFF
--- a/data/watson-pizzeria.json
+++ b/data/watson-pizzeria.json
@@ -1,1 +1,587 @@
-{"name":"WatsonPizzeria","created":"2017-07-19T18:23:21.630Z","intents":[{"intent":"help","created":"2017-07-19T18:23:49.397Z","updated":"2017-07-19T18:24:19.579Z","examples":[{"text":"help please","created":"2017-07-19T18:24:00.800Z","updated":"2017-07-19T18:24:00.800Z"},{"text":"What can I do","created":"2017-07-19T18:24:05.539Z","updated":"2017-07-19T18:24:05.539Z"},{"text":"help","created":"2017-07-19T18:24:07.845Z","updated":"2017-07-19T18:24:07.845Z"},{"text":"I don't understand","created":"2017-07-19T18:24:19.579Z","updated":"2017-07-19T18:24:19.579Z"}],"description":null},{"intent":"order","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:03:02.453Z","examples":[{"text":"Can I get a pizza margherita, small please","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z"},{"text":"I am hungry","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z"},{"text":"I want to order a large pizza","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z"},{"text":"I want to order a pizza","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z"},{"text":"I'd like a pizza","created":"2017-07-19T20:02:48.140Z","updated":"2017-07-19T20:02:48.140Z"},{"text":"order","created":"2017-07-19T20:02:55.022Z","updated":"2017-07-19T20:02:55.022Z"},{"text":"za","created":"2017-07-19T20:03:02.453Z","updated":"2017-07-19T20:03:02.453Z"}],"description":null},{"intent":"exit","created":"2017-07-19T18:24:45.981Z","updated":"2017-07-19T18:25:29.713Z","examples":[{"text":"I'm done","created":"2017-07-19T18:24:48.916Z","updated":"2017-07-19T18:24:48.916Z"},{"text":"exit","created":"2017-07-19T18:24:49.964Z","updated":"2017-07-19T18:24:49.964Z"},{"text":"cancel","created":"2017-07-19T18:24:59.439Z","updated":"2017-07-19T18:24:59.439Z"},{"text":"get me out","created":"2017-07-19T18:25:02.196Z","updated":"2017-07-19T18:25:02.196Z"},{"text":"get me out of here","created":"2017-07-19T18:25:29.713Z","updated":"2017-07-19T18:25:29.713Z"}],"description":null},{"intent":"reset","created":"2017-07-19T18:28:56.413Z","updated":"2017-07-19T18:29:13.407Z","examples":[{"text":"reset","created":"2017-07-19T18:29:03.784Z","updated":"2017-07-19T18:29:03.784Z"},{"text":"delete the inputs","created":"2017-07-19T18:29:08.109Z","updated":"2017-07-19T18:29:08.109Z"},{"text":"start again","created":"2017-07-19T18:29:10.444Z","updated":"2017-07-19T18:29:10.444Z"},{"text":"begin","created":"2017-07-19T18:29:13.407Z","updated":"2017-07-19T18:29:13.407Z"}],"description":null}],"updated":"2017-07-26T12:17:16.117Z","entities":[{"entity":"extra_confirmed","values":[{"value":"no","created":"2017-07-19T19:35:59.075Z","updated":"2017-07-19T19:35:59.075Z","metadata":null,"synonyms":[]},{"value":"yes","created":"2017-07-19T19:35:56.093Z","updated":"2017-07-19T19:35:57.693Z","metadata":null,"synonyms":[]}],"created":"2017-07-19T19:35:51.716Z","updated":"2017-07-19T21:17:53.831Z","metadata":null,"description":null},{"entity":"pizza_type","values":[{"value":"margherita","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"quatro formaggi","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"vegetarian","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":["vegetariana"]},{"value":"cheese","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]}],"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"description":null},{"entity":"pizza_place","values":[{"value":"go","created":"2017-07-26T11:46:48.833Z","updated":"2017-07-26T11:47:11.098Z","metadata":null,"synonyms":["home","take","take out"]},{"value":"stay","created":"2017-07-26T11:46:52.625Z","updated":"2017-07-26T11:47:34.334Z","metadata":null,"synonyms":["restaurant","eat in","eat there","dine in"]}],"created":"2017-07-26T11:46:45.640Z","updated":"2017-07-26T11:47:34.334Z","metadata":null,"description":null},{"entity":"pizza_toppings","values":[{"value":"cheese","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"ham","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"olive","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":["olives"]},{"value":"salami","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"onion","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"pepperoni","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"sausage","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"mushrooms","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:10:47.660Z","metadata":null,"synonyms":["mushroom"]},{"value":"anchovies","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:10:53.257Z","metadata":null,"synonyms":["anchovy"]}],"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:10:53.257Z","metadata":null,"description":null},{"entity":"pizza_size","values":[{"value":"large","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":[]},{"value":"medium","created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"synonyms":["regular"]},{"value":"small","created":"2017-07-19T20:03:35.456Z","updated":"2017-07-19T20:03:35.456Z","metadata":null,"synonyms":[]}],"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:03:35.456Z","metadata":null,"description":null}],"language":"en","metadata":null,"description":"Basic pizza ordering with optional topping, basic version with one attempt to provide toppings","dialog_nodes":[{"title":null,"output":{"text":{"values":["Let's start over."],"selection_policy":"sequential"}},"parent":null,"context":{"pizza_size":null,"pizza_type":null,"pizza_place":null,"pizza_toppings":null},"created":"2017-07-19T20:05:24.549Z","updated":"2017-07-26T12:17:16.117Z","metadata":null,"next_step":{"behavior":"jump_to","selector":"body","dialog_node":"Welcome"},"conditions":"#reset","description":null,"dialog_node":"Reset","previous_sibling":"Pizza ordering"},{"title":null,"output":{"text":{"values":["Welcome to Pizza Topping  Basic demonstration, you can order a pizza out of few selected types and sizes and add selected toppings. Ask for Help if needed."],"selection_policy":"sequential"}},"parent":null,"context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:12:39.591Z","metadata":null,"next_step":null,"conditions":"welcome","description":null,"dialog_node":"Welcome","previous_sibling":null},{"title":null,"output":{"text":{"values":["You can order a small, medium or large pizza. Types are Cheese, and you can add more ingredients, margherita, quatro formaggi, and vegetarian.","If  you want to start with cheese, you can add ingredients.  We offer pepperoni, sausage, ham, olive, onion, anchovies, mushrooms, or salami"],"selection_policy":"sequential"}},"parent":null,"context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:04:44.217Z","metadata":null,"next_step":null,"conditions":"anything_else","description":null,"dialog_node":"Fallback","previous_sibling":"Reset"},{"type":"frame","title":null,"output":{},"parent":null,"context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"next_step":null,"conditions":"#order","description":null,"dialog_node":"Pizza ordering","previous_sibling":"Welcome"},{"type":"response_condition","title":null,"output":{"text":{"values":["Thank you for ordering a $pizza_size $pizza_type pizza."],"selection_policy":"sequential"}},"parent":"Pizza ordering","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"next_step":null,"conditions":null,"description":null,"dialog_node":"node_8_1494705793073","previous_sibling":"node_19_1501070902849"},{"type":"response_condition","title":null,"output":{"text":{"values":["Thank you for ordering a $pizza_size $pizza_type pizza with <? $pizza_toppings.join(', ') ?> ."],"selection_policy":"sequential"}},"parent":"Pizza ordering","context":null,"created":"2017-07-26T12:08:23.164Z","updated":"2017-07-26T12:10:24.931Z","metadata":null,"next_step":null,"conditions":" $pizza_toppings && $pizza_toppings.size()>0","description":null,"dialog_node":"node_19_1501070902849","previous_sibling":"node_7_1494705728892"},{"type":"response_condition","title":null,"output":{"text":{"values":["Thank you for ordering a $pizza_size $pizza_type pizza with <? $pizza_toppings.join(', ') ?> . We'll plan on  <?$pizza_place == 'stay'? 'you eating here.' :  ' you taking this home'?>."],"selection_policy":"sequential"}},"parent":"Pizza ordering","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-26T12:15:40.774Z","metadata":null,"next_step":null,"conditions":"$pizza_toppings && $pizza_toppings.size()>0 && $pizza_place","description":null,"dialog_node":"node_7_1494705728892","previous_sibling":"handler_11_1500495509073"},{"type":"event_handler","title":null,"output":null,"parent":"slot_16_1501069677090","context":{"pizza_place":"@pizza_place"},"created":"2017-07-26T11:47:57.542Z","updated":"2017-07-26T11:48:03.889Z","metadata":null,"next_step":null,"conditions":"@pizza_place","event_name":"input","description":null,"dialog_node":"handler_17_1501069677090","previous_sibling":null},{"type":"event_handler","title":null,"output":null,"parent":"slot_3_1494421237824","context":{"pizza_size":"@pizza_size"},"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"next_step":null,"conditions":"@pizza_size","event_name":"input","description":null,"dialog_node":"handler_5_1494421285663","previous_sibling":"handler_4_1494421274527"},{"type":"event_handler","title":null,"output":{},"parent":"slot_1_1494704123064","context":{"pizza_toppings":"@pizza_toppings.values"},"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:38:14.249Z","metadata":null,"next_step":null,"conditions":"@pizza_toppings.values","event_name":"input","description":null,"dialog_node":"handler_2_1494704151628","previous_sibling":"handler_3_1494704424215"},{"type":"event_handler","title":null,"output":{},"parent":"slot_16_1501069677090","context":null,"created":"2017-07-26T11:47:57.796Z","updated":"2017-07-26T11:47:57.796Z","metadata":null,"next_step":null,"conditions":null,"event_name":"focus","description":null,"dialog_node":"handler_18_1501069677090","previous_sibling":"handler_17_1501069677090"},{"type":"event_handler","title":null,"output":{},"parent":"slot_6_1494421302730","context":{"pizza_type":"@pizza_type"},"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:28:56.822Z","metadata":null,"next_step":null,"conditions":"@pizza_type","event_name":"input","description":null,"dialog_node":"handler_8_1494421347721","previous_sibling":"handler_7_1494421336855"},{"type":"event_handler","title":null,"output":{"text":"Any extra toppings?"},"parent":"slot_1_1494704123064","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T21:18:04.754Z","metadata":null,"next_step":null,"conditions":null,"event_name":"focus","description":null,"dialog_node":"handler_3_1494704424215","previous_sibling":null},{"type":"event_handler","title":null,"output":{"text":"What size of pizza do you want (small, medium or large)"},"parent":"slot_3_1494421237824","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T20:04:18.384Z","metadata":null,"next_step":null,"conditions":null,"event_name":"focus","description":null,"dialog_node":"handler_4_1494421274527","previous_sibling":null},{"type":"event_handler","title":null,"output":{"text":"What type of pizza do you want? You can build your own starting with cheese, or choose quatro formaggi, margherita, or vegetarian.."},"parent":"slot_6_1494421302730","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:28:56.136Z","metadata":null,"next_step":null,"conditions":null,"event_name":"focus","description":null,"dialog_node":"handler_7_1494421336855","previous_sibling":null},{"type":"event_handler","title":null,"output":{"text":{"values":[]}},"parent":"slot_1_1494704123064","context":null,"created":"2017-07-19T18:53:17.939Z","updated":"2017-07-19T21:57:33.303Z","metadata":null,"next_step":null,"conditions":"","event_name":"filled","description":null,"dialog_node":"handler_4_1500489535722","previous_sibling":"handler_6_1494704751936"},{"type":"event_handler","title":null,"output":{"text":{"values":[]}},"parent":"slot_6_1494421302730","context":null,"created":"2017-07-19T19:28:57.138Z","updated":"2017-07-19T21:43:09.699Z","metadata":null,"next_step":null,"conditions":"","event_name":"filled","description":null,"dialog_node":"handler_5_1500492489376","previous_sibling":"handler_8_1494421347721"},{"type":"event_handler","title":null,"output":{"text":{"values":["No extra toppings,  O.K."]}},"parent":"slot_1_1494704123064","context":{"pizza_toppings":""},"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T21:18:29.627Z","metadata":null,"next_step":null,"conditions":"@extra_confirmed:no","event_name":"nomatch","description":null,"dialog_node":"handler_4_1494704594631","previous_sibling":"handler_4_1500489535722"},{"type":"event_handler","title":null,"output":{"text":{"values":["O.K., adding one extra @toppings"]}},"parent":"slot_1_1494704123064","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T21:43:54.886Z","metadata":null,"next_step":null,"conditions":"@pizza_toppings.length == 1","event_name":"filled","description":null,"dialog_node":"handler_5_1494704673688","previous_sibling":"handler_2_1494704151628"},{"type":"event_handler","title":null,"output":{"text":{"values":["O.K., adding @pizza_toppings.length more toppings to your pizza."]}},"parent":"slot_1_1494704123064","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:38:14.804Z","metadata":null,"next_step":null,"conditions":"@pizza_toppings.length > 1","event_name":"filled","description":null,"dialog_node":"handler_6_1494704751936","previous_sibling":"handler_5_1494704673688"},{"type":"event_handler","title":null,"output":{"text":{"values":["OK, let's start over."]}},"parent":"Pizza ordering","context":null,"created":"2017-07-19T20:20:05.202Z","updated":"2017-07-19T20:20:05.202Z","metadata":null,"next_step":null,"conditions":"#reset","event_name":"generic","description":null,"dialog_node":"handler_11_1500495509073","previous_sibling":"handler_10_1500495433159"},{"type":"event_handler","title":null,"output":{"text":{"values":["OK, which toppings would you like? We have pepperoni, sausage, ham, mushroom, onions, anchovy and olive."]}},"parent":"slot_1_1494704123064","context":null,"created":"2017-07-19T19:38:15.608Z","updated":"2017-07-19T21:18:44.601Z","metadata":null,"next_step":null,"conditions":"@extra_confirmed:yes","event_name":"nomatch","description":null,"dialog_node":"handler_8_1500493007853","previous_sibling":"handler_4_1494704594631"},{"type":"event_handler","title":null,"output":{"text":{"values":["You can choose size (small, medium, large), type (cheese, margherita, quatro formaggi, or vegetarian) and extra ingredients."]}},"parent":"Pizza ordering","context":null,"created":"2017-07-19T20:18:17.328Z","updated":"2017-07-19T20:20:05.176Z","metadata":null,"next_step":null,"conditions":"#help","event_name":"generic","description":null,"dialog_node":"handler_10_1500495433159","previous_sibling":null},{"type":"slot","title":null,"output":null,"parent":"Pizza ordering","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T18:23:21.630Z","metadata":null,"variable":"$pizza_size","next_step":null,"conditions":null,"description":null,"dialog_node":"slot_3_1494421237824","previous_sibling":"node_8_1494705793073"},{"type":"slot","title":null,"output":null,"parent":"Pizza ordering","context":null,"created":"2017-07-26T11:47:57.273Z","updated":"2017-07-26T11:48:03.630Z","metadata":null,"variable":"$pizza_place","next_step":null,"conditions":null,"description":null,"dialog_node":"slot_16_1501069677090","previous_sibling":"slot_1_1494704123064"},{"type":"slot","title":null,"output":{},"parent":"Pizza ordering","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:28:56.101Z","metadata":null,"variable":"$pizza_type","next_step":null,"conditions":null,"description":null,"dialog_node":"slot_6_1494421302730","previous_sibling":"slot_3_1494421237824"},{"type":"slot","title":null,"output":{},"parent":"Pizza ordering","context":null,"created":"2017-07-19T18:23:21.630Z","updated":"2017-07-19T19:38:13.465Z","metadata":null,"variable":"$pizza_toppings","next_step":null,"conditions":null,"description":null,"dialog_node":"slot_1_1494704123064","previous_sibling":"slot_6_1494421302730"}],"workspace_id":"60f09ec9-dcfb-469a-96b2-c0cea0d3e0f7","counterexamples":[],"learning_opt_out":null}
+{
+  "name": "WatsonPizzeria",
+  "intents": [
+    {
+      "intent": "help",
+      "examples": [
+        {
+          "text": "I don't understand"
+        },
+        {
+          "text": "help"
+        },
+        {
+          "text": "What can I do"
+        },
+        {
+          "text": "help please"
+        }
+      ]
+    },
+    {
+      "intent": "exit",
+      "examples": [
+        {
+          "text": "no"
+        },
+        {
+          "text": "get me out of here"
+        },
+        {
+          "text": "get me out"
+        },
+        {
+          "text": "cancel"
+        },
+        {
+          "text": "exit"
+        },
+        {
+          "text": "I'm done"
+        }
+      ]
+    },
+    {
+      "intent": "order",
+      "examples": [
+        {
+          "text": "I am hungry"
+        },
+        {
+          "text": "I'd like a pizza"
+        },
+        {
+          "text": "I want to order a pizza"
+        },
+        {
+          "text": "I want to order a large pizza"
+        },
+        {
+          "text": "Can I get a pizza margherita, small please"
+        },
+        {
+          "text": "za"
+        },
+        {
+          "text": "order"
+        }
+      ]
+    },
+    {
+      "intent": "reset",
+      "examples": [
+        {
+          "text": "begin"
+        },
+        {
+          "text": "start again"
+        },
+        {
+          "text": "delete the inputs"
+        },
+        {
+          "text": "reset"
+        }
+      ]
+    }
+  ],
+  "entities": [
+    {
+      "entity": "pizza_type",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "vegetarian",
+          "synonyms": [
+            "vegetariana"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "cheese",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "margherita",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "quatro formaggi",
+          "synonyms": []
+        }
+      ]
+    },
+    {
+      "entity": "pizza_toppings",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "mushrooms",
+          "synonyms": [
+            "mushroom"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "anchovies",
+          "synonyms": [
+            "anchovy"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "pepperoni",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "sausage",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "cheese",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "ham",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "olive",
+          "synonyms": [
+            "olives"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "salami",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "onion",
+          "synonyms": []
+        }
+      ]
+    },
+    {
+      "entity": "pizza_place",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "go",
+          "synonyms": [
+            "home",
+            "take",
+            "take out"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "stay",
+          "synonyms": [
+            "restaurant",
+            "eat in",
+            "eat there",
+            "dine in"
+          ]
+        }
+      ]
+    },
+    {
+      "entity": "extra_confirmed",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "no",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "yes",
+          "synonyms": []
+        }
+      ]
+    },
+    {
+      "entity": "pizza_size",
+      "values": [
+        {
+          "type": "synonyms",
+          "value": "large",
+          "synonyms": []
+        },
+        {
+          "type": "synonyms",
+          "value": "medium",
+          "synonyms": [
+            "regular"
+          ]
+        },
+        {
+          "type": "synonyms",
+          "value": "small",
+          "synonyms": []
+        }
+      ]
+    }
+  ],
+  "language": "en",
+  "metadata": {
+    "api_version": {
+      "major_version": "v1",
+      "minor_version": "2018-09-20"
+    }
+  },
+  "description": "Basic pizza ordering with optional topping, basic version with one attempt to provide toppings",
+  "dialog_nodes": [
+    {
+      "type": "event_handler",
+      "parent": "slot_3_1494421237824",
+      "context": {
+        "pizza_size": "@pizza_size"
+      },
+      "conditions": "@pizza_size",
+      "event_name": "input",
+      "dialog_node": "handler_5_1494421285663",
+      "previous_sibling": "handler_4_1494421274527"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": "What size of pizza do you want (small, medium or large)"
+      },
+      "parent": "slot_3_1494421237824",
+      "event_name": "focus",
+      "dialog_node": "handler_4_1494421274527"
+    },
+    {
+      "type": "event_handler",
+      "output": {},
+      "parent": "slot_16_1501069677090",
+      "event_name": "focus",
+      "dialog_node": "handler_18_1501069677090",
+      "previous_sibling": "handler_17_1501069677090"
+    },
+    {
+      "type": "event_handler",
+      "parent": "slot_16_1501069677090",
+      "context": {
+        "pizza_place": "@pizza_place"
+      },
+      "conditions": "@pizza_place",
+      "event_name": "input",
+      "dialog_node": "handler_17_1501069677090"
+    },
+    {
+      "type": "slot",
+      "parent": "Pizza ordering",
+      "variable": "$pizza_size",
+      "dialog_node": "slot_3_1494421237824",
+      "previous_sibling": "node_8_1494705793073"
+    },
+    {
+      "type": "slot",
+      "output": {},
+      "parent": "Pizza ordering",
+      "variable": "$pizza_type",
+      "dialog_node": "slot_6_1494421302730",
+      "previous_sibling": "slot_3_1494421237824"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "Thank you for ordering a $pizza_size $pizza_type pizza with <? $pizza_toppings.join(', ') ?> ."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "Pizza ordering",
+      "conditions": " $pizza_toppings && $pizza_toppings.size()>0",
+      "dialog_node": "node_19_1501070902849",
+      "previous_sibling": "node_7_1494705728892"
+    },
+    {
+      "type": "slot",
+      "output": {},
+      "parent": "Pizza ordering",
+      "metadata": {},
+      "variable": "$pizza_toppings",
+      "dialog_node": "slot_1_1494704123064",
+      "previous_sibling": "slot_6_1494421302730"
+    },
+    {
+      "type": "slot",
+      "parent": "Pizza ordering",
+      "variable": "$pizza_place",
+      "dialog_node": "slot_16_1501069677090",
+      "previous_sibling": "slot_1_1494704123064"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "Thank you for ordering a $pizza_size $pizza_type pizza."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "Pizza ordering",
+      "dialog_node": "node_8_1494705793073",
+      "previous_sibling": "node_19_1501070902849"
+    },
+    {
+      "type": "response_condition",
+      "output": {
+        "text": {
+          "values": [
+            "Thank you for ordering a $pizza_size $pizza_type pizza with <? $pizza_toppings.join(', ') ?> . We'll plan on  <?$pizza_place == 'stay'? 'you eating here.' :  ' you taking this home'?>."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "parent": "Pizza ordering",
+      "conditions": "$pizza_toppings && $pizza_toppings.size()>0 && $pizza_place",
+      "dialog_node": "node_7_1494705728892",
+      "previous_sibling": "handler_10_1500495433159"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "You can choose size (small, medium, large), type (cheese, margherita, quatro formaggi, or vegetarian) and extra ingredients."
+          ]
+        }
+      },
+      "parent": "Pizza ordering",
+      "metadata": {},
+      "conditions": "#help",
+      "event_name": "generic",
+      "dialog_node": "handler_10_1500495433159"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": []
+        }
+      },
+      "parent": "slot_6_1494421302730",
+      "conditions": "",
+      "event_name": "filled",
+      "dialog_node": "handler_5_1500492489376",
+      "previous_sibling": "handler_8_1494421347721"
+    },
+    {
+      "type": "event_handler",
+      "output": {},
+      "parent": "slot_6_1494421302730",
+      "context": {
+        "pizza_type": "@pizza_type"
+      },
+      "conditions": "@pizza_type",
+      "event_name": "input",
+      "dialog_node": "handler_8_1494421347721",
+      "previous_sibling": "handler_7_1494421336855"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": "What type of pizza do you want? You can build your own starting with cheese, or choose quatro formaggi, margherita, or vegetarian.."
+      },
+      "parent": "slot_6_1494421302730",
+      "event_name": "focus",
+      "dialog_node": "handler_7_1494421336855"
+    },
+    {
+      "type": "event_handler",
+      "output": {},
+      "parent": "slot_1_1494704123064",
+      "context": {
+        "pizza_toppings": "@pizza_toppings.values"
+      },
+      "metadata": {},
+      "conditions": "@pizza_toppings.values",
+      "event_name": "input",
+      "dialog_node": "handler_2_1494704151628",
+      "previous_sibling": "handler_3_1494704424215"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "No extra toppings,  O.K."
+          ]
+        }
+      },
+      "parent": "slot_1_1494704123064",
+      "context": {
+        "pizza_toppings": ""
+      },
+      "metadata": {},
+      "next_step": {
+        "behavior": "skip_all_slots"
+      },
+      "conditions": "@extra_confirmed:no",
+      "event_name": "nomatch",
+      "dialog_node": "handler_4_1494704594631",
+      "previous_sibling": "handler_4_1500489535722"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "O.K., adding @pizza_toppings.length more toppings to your pizza."
+          ]
+        }
+      },
+      "parent": "slot_1_1494704123064",
+      "metadata": {},
+      "conditions": "@pizza_toppings.length > 1",
+      "event_name": "filled",
+      "dialog_node": "handler_6_1494704751936",
+      "previous_sibling": "handler_5_1494704673688"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "OK, which toppings would you like? We have pepperoni, sausage, ham, mushroom, onions, anchovy and olive."
+          ]
+        }
+      },
+      "parent": "slot_1_1494704123064",
+      "metadata": {},
+      "conditions": "@extra_confirmed:yes",
+      "event_name": "nomatch",
+      "dialog_node": "handler_8_1500493007853",
+      "previous_sibling": "handler_4_1494704594631"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": [
+            "O.K., adding one extra @toppings"
+          ]
+        }
+      },
+      "parent": "slot_1_1494704123064",
+      "metadata": {},
+      "conditions": "@pizza_toppings.length == 1",
+      "event_name": "filled",
+      "dialog_node": "handler_5_1494704673688",
+      "previous_sibling": "handler_2_1494704151628"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": {
+          "values": []
+        }
+      },
+      "parent": "slot_1_1494704123064",
+      "metadata": {},
+      "event_name": "filled",
+      "dialog_node": "handler_4_1500489535722",
+      "previous_sibling": "handler_6_1494704751936"
+    },
+    {
+      "type": "event_handler",
+      "output": {
+        "text": "Any extra toppings?"
+      },
+      "parent": "slot_1_1494704123064",
+      "metadata": {},
+      "event_name": "focus",
+      "dialog_node": "handler_3_1494704424215"
+    },
+    {
+      "type": "frame",
+      "title": "Pizza ordering",
+      "output": {},
+      "metadata": {
+        "fallback": "leave"
+      },
+      "conditions": "#order",
+      "digress_in": "does_not_return",
+      "dialog_node": "Pizza ordering",
+      "digress_out": "allow_all",
+      "previous_sibling": "Welcome",
+      "digress_out_slots": "allow_all"
+    },
+    {
+      "type": "standard",
+      "title": "Fallback",
+      "output": {
+        "text": {
+          "values": [
+            "You can order a small, medium or large pizza. Types are Cheese, and you can add more ingredients, margherita, quatro formaggi, and vegetarian.",
+            "If  you want to start with cheese, you can add ingredients.  We offer pepperoni, sausage, ham, olive, onion, anchovies, mushrooms, or salami"
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "metadata": {},
+      "conditions": "anything_else",
+      "digress_in": "not_available",
+      "dialog_node": "Fallback",
+      "digress_out": "allow_all",
+      "previous_sibling": "Reset"
+    },
+    {
+      "type": "standard",
+      "output": {
+        "text": {
+          "values": [
+            "Let's start over."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "context": {
+        "pizza_size": null,
+        "pizza_type": null,
+        "pizza_place": null,
+        "pizza_toppings": null
+      },
+      "next_step": {
+        "behavior": "jump_to",
+        "selector": "body",
+        "dialog_node": "Welcome"
+      },
+      "conditions": "#reset",
+      "dialog_node": "Reset",
+      "previous_sibling": "Pizza ordering"
+    },
+    {
+      "type": "standard",
+      "output": {
+        "text": {
+          "values": [
+            "Welcome to Pizza Topping  Basic demonstration, you can order a pizza out of few selected types and sizes and add selected toppings. Ask for Help if needed."
+          ],
+          "selection_policy": "sequential"
+        }
+      },
+      "conditions": "welcome",
+      "dialog_node": "Welcome"
+    }
+  ],
+  "workspace_id": "0cfd1c60-30dd-42d1-9f61-a76b171b938e",
+  "counterexamples": [],
+  "learning_opt_out": false,
+  "status": "Available"
+}


### PR DESCRIPTION
The #help handler set within the Pizza ordering node prevents the correct
 processing of a "no" response to extra toppings (entity @extra_confirmed:no)
 in the dialog slot. The current trained model created after the workspace is
 built matches a "no" response to the #help intent and returns the handler
 message instead of going to the correct "Not Found" item for the slot with a
 response based on the entity value.

Fix:
By changing the default Digression processing for the Pizza ordering node, the
 #reset message handler can be eliminated entirely and allow the intended flow
 of the dialog to work for reset. Open settings on the node and select Digressions.
 Change the default to allow digressions from the node. Don't check "Only digress
 to slots that allow returns". Then delete the #reset handler in the Pizza
 ordering node.

Closes: #86