### PR TITLE
Change to use IAM apikey and url.

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -x
-export CONVERSATION_USERNAME=$(echo "$service_watson_conversation" | jq -r '.username')
-export CONVERSATION_PASSWORD=$(echo "$service_watson_conversation" | jq -r '.password')
+export CONVERSATION_IAM_APIKEY=$(echo "$service_watson_conversation" | jq -r '.apikey')
+export CONVERSATION_URL=$(echo "$service_watson_conversation" | jq -r '.url')
 npm start


### PR DESCRIPTION
The K8s deploy used username and password for old style
Watson assistant credentials.
Switch to using IAM apikey and URL.