### PR TITLE
sized icon smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When the reader has completed this Code Pattern, they will understand how to:
 
 ## Included Components
 
-> NOTE: This Code Pattern uses Watson Assistant V2. For a newly provisioned instance (after 10/8/2021), you can switch versions by going to the top-right corner of the Assistant screen and clicking the *Manage* icon <img title="a title" alt="Alt text" src="https://github.com/IBM/pattern-utils/blob/master/watson-assistant/person-icon.png" width="35" height="35">. Click on *Switch to classic experience* to use Assistant V1, and click on *Switch to new experience* to use Assistant V2.
+> **NOTE**: This Code Pattern uses Watson Assistant V2. For a newly provisioned instance (after 10/8/2021), you can switch versions by clicking the *Manage* icon <img title="a title" alt="manage-icon" src="https://github.com/IBM/pattern-utils/blob/master/watson-assistant/person-icon-sm.png" width="15" height="15"> located in the top-right corner of the Assistant screen. Click on *Switch to classic experience* to use Assistant V1, and click on *Switch to new experience* to use Assistant V2.
 
 * [IBM Watson Assistant](https://www.ibm.com/cloud/watson-assistant/): Build, test and deploy a bot or virtual agent across mobile devices, messaging platforms, or even on a physical robot.
 


### PR DESCRIPTION
- "manage" icon is smaller
- changed sentence around so that icon was not followed by a period, which didn't look good 